### PR TITLE
Edit the lemmas of 's to have instead of be when relevant.

### DIFF
--- a/en_lines-ud-dev.conllu
+++ b/en_lines-ud-dev.conllu
@@ -4761,7 +4761,7 @@
 3	a	a	DET	IND-SG	Definite=Ind|PronType=Art	4	det	_	_
 4	feeling	feeling	NOUN	SG-NOM	Number=Sing	2	obj	_	_
 5	there	there	PRON	EX	_	7	expl	_	SpaceAfter=No
-6	's	be	AUX	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	_	_
+6	's	have	AUX	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	_	_
 7	been	be	AUX	PERF	Tense=Past|VerbForm=Part	4	acl:relcl	_	_
 8	a	a	DET	IND-SG	Definite=Ind|PronType=Art	10	det	_	_
 9	terrible	terrible	ADJ	POS	Degree=Pos	10	amod	_	_
@@ -15008,7 +15008,7 @@
 8	state	state	NOUN	SG-NOM	Number=Sing	5	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	Comma	_	3	punct	_	_
 10	it	it	PRON	PERS-SG	_	15	nsubj	_	SpaceAfter=No
-11	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
+11	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
 12	got	get	AUX	PERF	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux	_	_
 13	to	to	PART	_	_	15	mark	_	_
 14	be	be	AUX	INF	VerbForm=Inf	15	cop	_	_

--- a/en_lines-ud-dev.conllu
+++ b/en_lines-ud-dev.conllu
@@ -14685,7 +14685,7 @@
 # sent_id = en_lines-ud-dev-doc6-3856
 # text = He's not come up to town?
 1	He	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
-2	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
+2	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	not	not	PART	NEG	_	4	advmod	_	_
 4	come	come	VERB	PERF	Tense=Past|VerbForm=Part	0	root	_	_
 5	up	up	ADV	_	_	4	compound:prt	_	_
@@ -19199,7 +19199,7 @@
 5	you	you	PRON	PERS-P2	_	4	obj	_	SpaceAfter=No
 6	,	,	PUNCT	Comma	_	9	punct	_	_
 7	Ron	Ron	PROPN	SG-GEN	Number=Sing	9	nsubj	_	SpaceAfter=No
-8	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	_	_
+8	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	told	tell	VERB	PERF	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
 10	us	we	PRON	PERS-P1PL-ACC	Case=Acc|Number=Plur|Person=1|PronType=Prs	9	obj	_	_
 11	so	so	ADV	_	_	12	advmod	_	_

--- a/en_lines-ud-test.conllu
+++ b/en_lines-ud-test.conllu
@@ -15121,14 +15121,14 @@
 12	alone	alone	ADJ	POS	Degree=Pos	10	xcomp	_	SpaceAfter=No
 13	,	,	PUNCT	Comma	_	16	punct	_	_
 14	he	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	SpaceAfter=No
-15	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
+15	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
 16	learnt	learn	VERB	PERF	Tense=Past|VerbForm=Part	5	conj	_	_
 17	a	a	DET	IND-SG	Definite=Ind|PronType=Art	18	det	_	_
 18	lot	lot	NOUN	SG-NOM	Number=Sing	16	obj	_	SpaceAfter=No
 19	,	,	PUNCT	Comma	_	23	punct	_	_
 20	and	and	CCONJ	_	_	23	cc	_	_
 21	one	one	PRON	IND-P3SG	_	23	nsubj	_	SpaceAfter=No
-22	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	_	_
+22	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	_	_
 23	done	do	VERB	PERF	Tense=Past|VerbForm=Part	5	conj	_	_
 24	what	what	PRON	WH-REL	PronType=Rel	23	obj	_	_
 25	one	one	PRON	IND-P3SG	_	26	nsubj	_	_
@@ -15330,7 +15330,7 @@
 11	,	,	PUNCT	Comma	_	15	punct	_	_
 12	but	but	CCONJ	_	_	15	cc	_	_
 13	he	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	SpaceAfter=No
-14	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
+14	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
 15	refused	refuse	VERB	PAST	Mood=Ind|Tense=Past|VerbForm=Fin	6	conj	_	_
 16	to	to	PART	_	_	17	mark	_	_
 17	touch	touch	VERB	INF	VerbForm=Inf	15	xcomp	_	_

--- a/en_lines-ud-test.conllu
+++ b/en_lines-ud-test.conllu
@@ -14838,7 +14838,7 @@
 3	says	say	VERB	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	her	she	PRON	P3SG-GEN	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
 5	secretary	secretary	NOUN	SG-NOM	Number=Sing	8	nsubj	_	SpaceAfter=No
-6	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
+6	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
 7	been	be	AUX	PERF	Tense=Past|VerbForm=Part	8	aux	_	_
 8	trying	try	VERB	ING	Tense=Pres|VerbForm=Part	3	ccomp	_	_
 9	to	to	PART	_	_	10	mark	_	_
@@ -15684,7 +15684,7 @@
 10	,	,	PUNCT	Comma	_	15	punct	_	_
 11	and	and	CCONJ	_	_	15	cc	_	_
 12	she	she	PRON	PERS-SG-NOM	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	SpaceAfter=No
-13	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
+13	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
 14	been	be	AUX	PERF	Tense=Past|VerbForm=Part	15	aux	_	_
 15	trying	try	VERB	ING	Tense=Pres|VerbForm=Part	3	conj	_	_
 16	it	it	PRON	PERS-SG	_	15	obj	_	_
@@ -15788,7 +15788,7 @@
 3	your	you	PRON	P2-GEN	Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	angle	angle	NOUN	SG-NOM	Number=Sing	5	compound	_	_
 5	lamp	lamp	NOUN	SG-NOM	Number=Sing	8	nsubj:pass	_	SpaceAfter=No
-6	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux:pass	_	_
+6	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux:pass	_	_
 7	been	be	AUX	PERF	Tense=Past|VerbForm=Part	8	aux:pass	_	_
 8	left	leave	VERB	PASS	Tense=Past|VerbForm=Part|Voice=Pass	2	ccomp	_	_
 9	at	at	ADP	_	_	11	case	_	_
@@ -15876,7 +15876,7 @@
 # sent_id = en_lines-ud-test-doc6-4988
 # text = He's never been sent anywhere where there was anything left to do, he said.
 1	He	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj:pass	_	SpaceAfter=No
-2	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
+2	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
 3	never	never	ADV	NEG	_	5	advmod	_	_
 4	been	be	AUX	PERF	Tense=Past|VerbForm=Part	5	aux:pass	_	_
 5	sent	send	VERB	PASS	Tense=Past|VerbForm=Part|Voice=Pass	16	ccomp	_	_
@@ -15906,7 +15906,7 @@
 9	,	,	PUNCT	Comma	_	14	punct	_	_
 10	after	after	SCONJ	_	_	14	mark	_	_
 11	self-government	self-government	NOUN	SG-NOM	Number=Sing	14	nsubj:pass	_	SpaceAfter=No
-12	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux:pass	_	_
+12	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux:pass	_	_
 13	been	be	AUX	PERF	Tense=Past|VerbForm=Part	14	aux:pass	_	_
 14	granted	grant	VERB	PASS	Tense=Past|VerbForm=Part|Voice=Pass	3	advcl	_	_
 15	and	and	CCONJ	_	_	22	cc	_	_
@@ -15914,7 +15914,7 @@
 17	date	date	NOUN	SG-NOM	Number=Sing	22	nsubj:pass	_	_
 18	for	for	ADP	_	_	19	case	_	_
 19	independence	independence	NOUN	SG-NOM	Number=Sing	17	nmod	_	SpaceAfter=No
-20	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux:pass	_	_
+20	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux:pass	_	_
 21	been	be	AUX	PERF	Tense=Past|VerbForm=Part	22	aux:pass	_	_
 22	given	give	VERB	PASS	Tense=Past|VerbForm=Part|Voice=Pass	14	conj	_	SpaceAfter=No
 23	.	.	PUNCT	Period	_	3	punct	_	_
@@ -15976,7 +15976,7 @@
 5	months	month	NOUN	PL-NOM	Number=Plur	3	obl	_	_
 6	ago	ago	ADP	_	Case=Nom	5	case	_	_
 7	there	there	PRON	EX	_	11	expl	_	SpaceAfter=No
-8	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
+8	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
 9	been	be	AUX	PERF	Tense=Past|VerbForm=Part	11	cop	_	_
 10	damn	damn	ADV	_	_	11	advmod	_	_
 11	all	all	PRON	TOT-SG	Case=Nom	0	root	_	_

--- a/en_lines-ud-train.conllu
+++ b/en_lines-ud-train.conllu
@@ -9182,7 +9182,7 @@
 # sent_id = en_lines-ud-train-doc2-432
 # text = He's been waiting for you since eight o'clock.
 1	He	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
-2	's	be	AUX	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
+2	's	have	AUX	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	been	be	AUX	PERF	Tense=Past|VerbForm=Part	4	aux	_	_
 4	waiting	wait	VERB	ING	Tense=Pres|VerbForm=Part	0	root	_	_
 5	for	for	ADP	_	_	6	case	_	_
@@ -9220,7 +9220,7 @@
 # sent_id = en_lines-ud-train-doc2-435
 # text = He's been frantic, the woman explained.
 1	He	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
-2	's	be	AUX	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
+2	's	have	AUX	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	been	be	AUX	PERF	Tense=Past|VerbForm=Part	4	cop	_	_
 4	frantic	frantic	ADJ	POS	Degree=Pos	8	xcomp	_	SpaceAfter=No
 5	,	,	PUNCT	Comma	_	4	punct	_	_
@@ -44069,7 +44069,7 @@
 # sent_id = en_lines-ud-train-doc6-2078
 # text = He's just been to Denmark or somewhere because his mother died.
 1	He	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
-2	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
+2	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	just	just	ADV	_	_	4	advmod	_	_
 4	been	be	AUX	PERF	Tense=Past|VerbForm=Part	0	root	_	_
 5	to	to	ADP	_	_	6	case	_	_
@@ -47937,7 +47937,7 @@
 17	some	some	DET	IND	_	18	det	_	_
 18	nights	night	NOUN	PL-NOM	Number=Plur	21	obl	_	_
 19	it	it	PRON	PERS-SG	_	21	nsubj	_	SpaceAfter=No
-20	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
+20	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
 21	been	be	AUX	PERF	Tense=Past|VerbForm=Part	5	conj	_	_
 22	until	until	ADP	_	_	23	case	_	_
 23	ten	ten	NUM	ID	NumType=Card	21	obl	_	SpaceAfter=No
@@ -50075,7 +50075,7 @@
 # sent_id = en_lines-ud-train-doc6-2341
 # text = Rebecca's been to the Sputnik and she says it's terrific now.
 1	Rebecca	Rebecca	PROPN	SG-NOM	Number=Sing	3	nsubj	_	SpaceAfter=No
-2	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	_	_
+2	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	been	be	AUX	PERF	Tense=Past|VerbForm=Part	0	root	_	_
 4	to	to	ADP	_	_	6	case	_	_
 5	the	the	DET	DEF	Definite=Def|PronType=Art	6	det	_	_
@@ -50132,7 +50132,7 @@
 3	one	one	PRON	IND-P3SG	_	8	nsubj	_	_
 4	of	of	ADP	_	_	5	case	_	_
 5	us	we	PRON	PERS-P1PL-ACC	Case=Acc|Number=Plur|Person=1|PronType=Prs	3	nmod	_	SpaceAfter=No
-6	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
+6	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
 7	been	be	AUX	PERF	Tense=Past|VerbForm=Part	8	aux	_	_
 8	taking	take	VERB	ING	Tense=Pres|VerbForm=Part	0	root	_	_
 9	Rebecca	Rebecca	PROPN	SG-NOM	Number=Sing	8	obj	_	_

--- a/en_lines-ud-train.conllu
+++ b/en_lines-ud-train.conllu
@@ -44167,7 +44167,7 @@
 # sent_id = en_lines-ud-train-doc6-2084
 # text = it's got the character of the miners' pub it was, but it's very handy for the new government offices, not too overawing, so you get quite a few Africans coming in.
 1	it	it	PRON	PERS-SG	_	3	nsubj	_	SpaceAfter=No
-2	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	_	_
+2	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	got	get	VERB	PERF	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	the	the	DET	DEF	Definite=Def|PronType=Art	5	det	_	_
 5	character	character	NOUN	SG-NOM	Number=Sing	3	obj	_	_
@@ -44307,7 +44307,7 @@
 2	tell	tell	VERB	PRES	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	me	I	PRON	PERS-P1SG-ACC	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
 4	he	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	SpaceAfter=No
-5	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+5	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	got	get	VERB	PERF	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	_	_
 7	the	the	DET	DEF	Definite=Def|PronType=Art	8	det	_	_
 8	contract	contract	NOUN	SG-NOM	Number=Sing	6	obj	_	_
@@ -45151,7 +45151,7 @@
 # text = Anyone who's stayed on is a fool if he hasn't thought about that, said Bray.
 1	Anyone	anyone	PRON	IND-SG-NOM	Number=Sing	8	nsubj	_	_
 2	who	who	PRON	WH-REL	PronType=Rel	4	nsubj	_	SpaceAfter=No
-3	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
+3	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	stayed	stay	VERB	PERF	Mood=Ind|Tense=Past|VerbForm=Fin	1	acl:relcl	_	_
 5	on	on	ADV	_	_	4	compound:prt	_	_
 6	is	be	AUX	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
@@ -48025,7 +48025,7 @@
 28	great	great	ADJ	POS	Degree=Pos	29	nmod:poss	_	_
 29	men	man	NOUN	PL-NOM	Number=Plur	26	obj	_	_
 30	he	he	PRON	PERS-P3SG-NOM	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	32	nsubj	_	SpaceAfter=No
-31	's	be	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	aux	_	_
+31	's	have	AUX	PRES-AUX	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	aux	_	_
 32	seen	see	VERB	PERF	Tense=Past|VerbForm=Part	29	acl:relcl	_	_
 33	in	in	ADP	_	_	35	case	_	_
 34	the	the	DET	DEF	Definite=Def|PronType=Art	35	det	_	_


### PR DESCRIPTION
In general, this occurs when 's is followed by another AUX, sometimes with an intervening ADV.

Edits enacted with the following ssurgeon script which reflects those observations:

{word:/'s/;lemma:be}=has < {cpos:AUX}
editNode -node has -lemma have

{} > {word:/'s/;lemma:be}=has > {cpos:AUX}=other : {}=has .. ({cpos:ADV} .. {}=other) editNode -node has -lemma have

{} > {word:/'s/;lemma:be}=has > {cpos:AUX}=other : {}=has . {}=other editNode -node has -lemma have